### PR TITLE
Allow a function to be specified for the 'exec' parameter

### DIFF
--- a/MMM-NotificationTrigger.js
+++ b/MMM-NotificationTrigger.js
@@ -57,30 +57,35 @@ Module.register("MMM-NotificationTrigger", {
 				if (senderFilter(sender) && payloadFilter(payload)) {
 					for(j in trigger.fires) {
 						var fire = trigger.fires[j]
-						var result = payload
+						var payload_result = payload
 						if (typeof fire.payload == "function") {
-							result = fire.payload(payload)
+							payload_result = fire.payload(payload)
 						} else if (fire.payload) {
-							result = fire.payload
+							payload_result = fire.payload
 						}
+						var exec_result = fire.exec
+						if (exec_result && typeof exec_result == "function") {
+							exec_result = exec_result(payload)
+						}
+
 						if(fire.delay) {
 							setTimeout(()=>{
-								this.sendNotification(fire.fire, result)
-								if (fire.exec) {
+								this.sendNotification(fire.fire, payload_result)
+								if (exec_result) {
 									this.sendSocketNotification("EXEC", {
 										trigger:trigger.trigger,
 										fire: fire.fire,
-										exec:fire.exec
+										exec: exec_result
 									})
 								}
 							}, fire.delay)
 						} else {
-							this.sendNotification(fire.fire, result)
-							if (fire.exec) {
+							this.sendNotification(fire.fire, payload_result)
+							if (exec_result) {
 								this.sendSocketNotification("EXEC", {
 									trigger:trigger.trigger,
 									fire: fire.fire,
-									exec:fire.exec
+									exec: exec_result
 								})
 							}
 						}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ git clone https://github.com/eouia/MMM-NotificationTrigger.git
               return payload
             },
             delay: 1000, //OPTIONAL, if this is set, your outgoing notification will be fired after delay.
-            exec: "ls -l" //OPTIONAL, if exists, this script will be executed, and the result will be returned with "OUTGOING_NOTIFICATION_RESULT" and payload
+            exec: "ls -l" //OPTIONAL, if exists, this script will be executed, and the result will be returned with "OUTGOING_NOTIFICATION_RESULT" and payload.  Can also be specified as a function which accepts the payload as an argument and returns the command to execute.
           },
         ],
       },


### PR DESCRIPTION
The exec parameter can now be specified as a function which accepts the
incoming payload as an argument and returns the command to be
executed.  