### PR TITLE
Fix for firing multiple delayed notifications

### DIFF
--- a/MMM-NotificationTrigger.js
+++ b/MMM-NotificationTrigger.js
@@ -69,16 +69,16 @@ Module.register("MMM-NotificationTrigger", {
 						}
 
 						if(fire.delay) {
-							setTimeout(()=>{
-								this.sendNotification(fire.fire, payload_result)
-								if (exec_result) {
+							setTimeout((fire, trigger, payload, exec) => {
+								this.sendNotification(fire, payload)
+								if (exec) {
 									this.sendSocketNotification("EXEC", {
-										trigger:trigger.trigger,
-										fire: fire.fire,
-										exec: exec_result
+										trigger:trigger,
+										fire: fire,
+										exec: exec
 									})
 								}
-							}, fire.delay)
+							}, fire.delay, fire.fire, trigger.trigger, payload_result, exec_result)
 						} else {
 							this.sendNotification(fire.fire, payload_result)
 							if (exec_result) {


### PR DESCRIPTION
This will fix the firing of multiple notifications if a delay is used.

```
{
  trigger: "SPOTIFY_PLAYLIST_AUTO",
  fires: [
    {
      fire: "SPOTIFY_SHUFFLE_ON",
      delay: 500,
    },
    {
      fire: "SPOTIFY_TRANSFER",
      delay: 1000,
      payload: (params) => {
        return "Living Room";
      },
    },
    {
      fire: "SPOTIFY_NEXT",
      delay: 1500,
    }
  ]
},

```

Originally only the last SPOTIFY_NEXT notification was fired three times.